### PR TITLE
Remove Fixnum

### DIFF
--- a/lib/message.rb
+++ b/lib/message.rb
@@ -78,12 +78,12 @@ class HL7::Message
   end
 
   # access a segment of the message
-  # index:: can be a Range, Fixnum or anything that
+  # index:: can be a Range, Integer or anything that
   #         responds to to_sym
   def []( index )
     ret = nil
 
-    if index.kind_of?(Range) || index.kind_of?(Fixnum)
+    if index.kind_of?(Range) || index.kind_of?(Integer)
       ret = @segments[ index ]
     elsif (index.respond_to? :to_sym)
       ret = @segments_by_name[ index.to_sym ]
@@ -94,7 +94,7 @@ class HL7::Message
   end
 
   # modify a segment of the message
-  # index:: can be a Range, Fixnum or anything that
+  # index:: can be a Range, Integer or anything that
   #         responds to to_sym
   # value:: an HL7::Message::Segment object
   def []=( index, value )
@@ -102,12 +102,12 @@ class HL7::Message
       raise HL7::Exception.new( "attempting to assign something other than an HL7 Segment" )
     end
 
-    if index.kind_of?(Range) || index.kind_of?(Fixnum)
+    if index.kind_of?(Range) || index.kind_of?(Integer)
       @segments[ index ] = value
     elsif index.respond_to?(:to_sym)
       (@segments_by_name[ index.to_sym ] ||= []) << value
     else
-      raise HL7::Exception.new( "attempting to use an indice that is not a Range, Fixnum or to_sym providing object" )
+      raise HL7::Exception.new( "attempting to use an indice that is not a Range, Integer or to_sym providing object" )
     end
 
     value.segment_parent = self

--- a/lib/segment_fields.rb
+++ b/lib/segment_fields.rb
@@ -78,8 +78,8 @@ module HL7::Message::SegmentFields
 
   def field_info( name ) #:nodoc:
     field_blk = nil
-    idx = name # assume we've gotten a fixnum
-    unless name.kind_of?( Fixnum )
+    idx = name # assume we've gotten a integer
+    unless name.kind_of?(Integer)
       fld_info = self.class.fields[ name ]
       idx = fld_info[:idx].to_i
       field_blk = fld_info[:blk]


### PR DESCRIPTION
Cherry pick 74e26d3 from upstream to get rid of Fixnum-related deprecation warnings on Ruby 2.4.