### PR TITLE
TT-189 - feat(initializer): Add an initializer to add and update segments definition

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,20 @@
+class HL7::Configuration
+  attr_reader :segments
+
+  def initialize
+    @segments = Segments.new
+  end
+
+  class Segments
+    def add(segment_name, &block)
+      segment_class = Class.new(HL7::Message::Segment, &block)
+      HL7::Message::Segment.const_set(segment_name, segment_class)
+    end
+
+    def update(segment_name, &block)
+      HL7::Message::Segment
+        .const_get(segment_name)
+        .instance_eval(&block)
+    end
+  end
+end

--- a/lib/ruby-hl7.rb
+++ b/lib/ruby-hl7.rb
@@ -25,6 +25,11 @@ module HL7 # :nodoc:
   def self.ParserConfig
     @parser_cfg ||= { :empty_segment_is_error => true }
   end
+
+  def self.configure
+    @configuration ||= Configuration.new
+    yield(@configuration)
+  end
 end
 
 # Encapsulate HL7 specific exceptions
@@ -48,6 +53,7 @@ end
 class HL7::EmptySegmentNotAllowed < HL7::ParseError
 end
 
+require 'configuration'
 require 'message_parser'
 require 'message'
 require 'segment_list_storage'

--- a/lib/segment_fields.rb
+++ b/lib/segment_fields.rb
@@ -36,6 +36,11 @@ module HL7::Message::SegmentFields
       end
 
       self.class_eval <<-END
+        if :#{name} != :name
+          remove_method(:#{name}) if method_defined?(:#{name})
+          remove_method(:"#{name}=") if method_defined?(:"#{name}=")
+        end
+
         def #{name}(val=nil)
           unless val
             read_field( :#{namesym} )

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,76 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe HL7::Message do
+  context 'add a new segment' do
+    before(:all) do
+      HL7.configure do |config|
+        config.segments.add(:ZXX) do
+          weight 1000
+          add_field :id
+          add_field :ownership
+          add_field :value
+        end
+      end
+
+      @base_msh = "MSH|^~\\&|LAB1||DESTINATION||19910127105114||ORU^R03|LAB1003929"
+      @base_zxx = "ZXX|custom_field_1|NOT_ME|custom_value_1"
+      @message = "#{@base_msh}\r#{@base_zxx}"
+    end
+
+    after(:all) do
+      HL7::Message::Segment.send(:remove_const, :ZXX)
+    end
+
+    it 'parses all lines' do
+      msg = HL7::Message.new
+      msg.parse(@message)
+      msg.to_hl7.should(eq(@message))
+    end
+
+    it 'allows access to new segment elements' do
+      msg = HL7::Message.new
+      msg.parse(@message)
+
+      msg[:ZXX].id.should(eq('custom_field_1'))
+      msg[:ZXX].ownership.should(eq('NOT_ME'))
+      msg[:ZXX].value.should(eq('custom_value_1'))
+    end
+
+    it 'allows modification of segment elements' do
+      msg = HL7::Message.new
+      msg.parse(@message)
+
+      msg[:ZXX].ownership = 'YOU'
+      msg[:ZXX].ownership.should(eq('YOU'))
+    end
+  end
+
+  context 'override an existing segment' do
+    before(:all) do
+      HL7.configure do |config|
+        config.segments.update(:PID) do
+          add_field :admin_sex, idx: 8
+          add_field :awesome_field
+        end
+      end
+    end
+
+    after(:all) do
+      HL7::Message::Segment.send(:remove_const, :PID)
+      require_relative '../lib/segments/pid'
+    end
+
+    it 'allows to bypass the validation on admin_sex by re-defining the field' do
+      pid = HL7::Message::Segment::PID.new
+      lambda { pid.admin_sex = 'Male' }.should_not(raise_error)
+      pid.admin_sex.should(eq('Male'))
+    end
+
+    it 'allows to add a field to an existing segment' do
+      pid = HL7::Message::Segment::PID.new
+      lambda { pid.awesome_field = 'You are a-ma-zing.' }.should_not(raise_error)
+      pid.awesome_field.should(eq('You are a-ma-zing.'))
+    end
+  end
+end


### PR DESCRIPTION
Hello,

This PR adds an initializer to the gem.
Before, to add or update a segment, an ugly monkey-patch was required:
```ruby
# Add a segment
class HL7::Message::Segment::ZCF < HL7::Message::Segment
  weight 1000
  add_field :foo
  add_field :bar
end

# Override some fields of an existing segment
class HL7::Message::Segment::PID
  add_field :admin_sex, idx: 8
end
```

Now, a proper initializer allows to do:
```ruby
HL7.configure do |config|
  # Add a segment
  config.segments.add(:ZCF) do
    weight 1000
    add_field :foo
    add_field :bar
  end

  # Override some fields of an existing segment
  config.segments.update(:PID) do
    add_field :admin_sex, idx: 8
  end
end
```