### PR TITLE
Enforce MSH Encoding on HL7 Messages

### DIFF
--- a/lib/message.rb
+++ b/lib/message.rb
@@ -196,6 +196,9 @@ class HL7::Message
     end
   end
 
+  def enforce_encoding!
+  end
+
   private
   def generate_segments( ary )
     raise HL7::ParseError.new( "no array to generate segments" ) unless ary.length > 0

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -200,10 +200,12 @@ class HL7::Message
     end
   end
 
-  def enforce_encoding!
+  def enforce_encoding!(element)
+    return unless self[:MSH] && POSSIBLE_ENCODINGS.include?(self[:MSH].charset)
+
+    current_encoding = element.encoding.to_s
     encoding = self[:MSH].charset
-    to_s.force_encoding(encoding).encode(encoding)
-    # self
+    element.force_encoding(current_encoding).encode!(encoding)
   end
 
   private
@@ -234,11 +236,7 @@ class HL7::Message
                                                             @delimiter )
 
     return nil unless segment_generator.valid_segments_parts?
-    if self[:MSH] && POSSIBLE_ENCODINGS.include?(self[:MSH].charset)
-      current_encoding = segment_generator.element.encoding.to_s
-      encoding = self[:MSH].charset
-      segment_generator.element.force_encoding(current_encoding).encode!(encoding)
-    end
+    enforce_encoding!(segment_generator.element)
     segment_generator.seg_name = segment_generator.seg_parts[0]
 
     new_seg = segment_generator.build

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -63,7 +63,9 @@ class HL7::Message
 
   def parse( inobj )
     if inobj.kind_of?(String)
-      generate_segments( message_parser.parse_string( inobj ))
+      encoding = inobj.detect_encoding
+      generate_segments( message_parser.parse_string( inobj.dup.force_encoding(encoding).encode(encoding) ))
+      enforce_encoding!
     elsif inobj.respond_to?(:each)
       generate_segments_enumerable(inobj)
     else
@@ -197,6 +199,9 @@ class HL7::Message
   end
 
   def enforce_encoding!
+    encoding = self[:MSH].charset
+    to_s.force_encoding(encoding).encode(encoding)
+    # self
   end
 
   private
@@ -271,5 +276,6 @@ class HL7::Message
    def get_symbol_from_name(seg_name)
     seg_name.to_s.strip.length > 0 ? seg_name.to_sym : nil
   end
+
 
 end

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -67,7 +67,7 @@ class HL7::Message
   def parse( inobj )
     if inobj.kind_of?(String)
       encoding = inobj.detect_encoding
-      generate_segments( message_parser.parse_string( inobj.dup.force_encoding(encoding).encode(encoding) ))
+      generate_segments( message_parser.parse_string( inobj.dup.force_encoding(encoding) ))
     elsif inobj.respond_to?(:each)
       generate_segments_enumerable(inobj)
     else

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -29,7 +29,6 @@
 #  puts "message type: %s" % msg[:MSH].message_type
 #
 #
-
 class HL7::Message
   include Enumerable # we treat an hl7 2.x message as a collection of segments
   extend HL7::MessageBatchParser
@@ -66,8 +65,7 @@ class HL7::Message
 
   def parse( inobj )
     if inobj.kind_of?(String)
-      encoding = inobj.detect_encoding
-      generate_segments( message_parser.parse_string( inobj.dup.force_encoding(encoding) ))
+      generate_segments( message_parser.parse_string( inobj ))
     elsif inobj.respond_to?(:each)
       generate_segments_enumerable(inobj)
     else

--- a/lib/message_parser.rb
+++ b/lib/message_parser.rb
@@ -56,8 +56,10 @@ class HL7::MessageParser
 
   # parse the provided String or Enumerable object into this message
   def parse_string( instr )
-    post_mllp = instr
-    if /\x0b((:?.|\r|\n)+)\x1c\r/.match( instr )
+    valid_instr = instr.dup.force_encoding(instr.detect_encoding)
+    post_mllp = valid_instr
+
+    if /\x0b((:?.|\r|\n)+)\x1c\r/.match( valid_instr )
       post_mllp = $1 #strip the mllp bytes
     end
     HL7::MessageParser.split_by_delimiter(post_mllp, @delimiter.segment)

--- a/lib/ruby-hl7.rb
+++ b/lib/ruby-hl7.rb
@@ -58,6 +58,10 @@ class String
     self.gsub("\\E\\", '\\').gsub("\\F\\", '|').gsub("\\T\\", '&').gsub("\\R\\", '~').gsub("\\S\\", '^').gsub("\\.br\\", "\n")
   end
 
+  def detect_encoding
+    valid_encoding? ? "UTF-8" : "ISO-8859-1"
+  end
+
 end
 
 require 'message_parser'

--- a/lib/segment.rb
+++ b/lib/segment.rb
@@ -154,6 +154,12 @@ class HL7::Message::Segment
     self.respond_to?(:children)
   end
 
+  def enforce_encoding!(current_encoding, encoding)
+    @elements = @elements.map do |element|
+      element.force_encoding(current_encoding).encode(encoding)
+    end
+  end
+
   private
   def self.singleton #:nodoc:
     class << self; self end

--- a/spec/enforce_encoding_spec.rb
+++ b/spec/enforce_encoding_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe 'enforce encoding' do
   before :all do
-    @gen = <<~HL7.tr("\n", "\r").chop
+    @gen = <<~HL7.gsub("\n", "\r").chop
       MSH|^~\\&|Doctolib||Doctolib||20160720182415||SIU^S12|a40e0c06-4101-4f60-9|P|2.5.1|||||FRA|UTF-8
       SCH||369016^DXPLANNING||||APT|||||1^MIN^15^201602250945|^CHANTELOUP^ELISE||||jdelon^DELON^Jeremie||||jdelon^DELON^Jeremie||||393923^DXPLANNING
       PID|||DXP738874^^^DX_TEMPORY^PI~DX0738874^^^DX_TEMPORY^PI||TEST^SIMONE^^^^^D~MAIDEN NAME^SIMONE^^^^^L||19900201|F|||38 RUE GERMAIN ET ROGER LEFEVRE^^PARAY VIEILLE POSTE^^91550||C^^^simone.test@gma.com~C0655554444|C0199998888||||
@@ -12,14 +12,37 @@ describe 'enforce encoding' do
       AIL|1|A|GASTRO^^^00001^^D|E
       AIP|1|A|1196^MARTY^Olivier|M
     HL7
+
+    @bad = <<~HL7.gsub("\n", "\r").chop
+      MSH|^~\\&|Doctolib||Doctolib||20160720182415||SIU^S12|a40e0c06-4101-4f60-9|P|2.5.1|||||FRA|UTF-8
+      SCH||369016^DXPLANNING||||APT|||||1^MIN^15^201602250945|^CHANTELOUP^ELISE||||jdelon^DELON^Joaqu\xEDn||||jdelon^DELON^Joaqu\xEDn||||393923^DXPLANNING
+      PID|||DXP738874^^^DX_TEMPORY^PI~DX0738874^^^DX_TEMPORY^PI||TEST^SIMONE^^^^^D~MAIDEN NAME^SIMONE^^^^^L||19900201|F|||38 RUE GERMAIN ET ROGER LEFEVRE^^PARAY VIEILLE POSTE^^91550||C^^^simone.test@gma.com~C0655554444|C0199998888||||
+      RGS|1
+      AIS|1|A|ANGAS^CS GASTRO ANCIEN^1|201602250945|201602250945||15|MIN|||1^I^L
+      AIL|1|A|GASTRO^^^00001^^D|E
+      AIP|1|A|1196^MARTY^Olivier|M
+    HL7
   end
-  context 'general' do
-    it do
+
+  context 'when msh charset and text encoding agrees' do
+    it 'keeps both encoding and charset as is' do
       msg = HL7::Message.new(@gen)
 
-      msg.enforce_encoding!
+      expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset.strip)
+    end
+  end
 
-      expect(@gen.to_s.encoding.name).to eql(msg[:MSH].charset)
+  context 'when msh charset and text encoding differs' do
+    it 'enforces charset on the message' do
+      msg = HL7::Message.new(@bad)
+
+      expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset)
+    end
+
+    it 'is expected to have a valid encoding' do
+      msg = HL7::Message.new(@bad)
+
+      expect(msg.to_s).to be_valid_encoding
     end
   end
 end

--- a/spec/enforce_encoding_spec.rb
+++ b/spec/enforce_encoding_spec.rb
@@ -1,0 +1,25 @@
+require 'pry'
+require 'spec_helper'
+
+describe 'enforce encoding' do
+  before :all do
+    @gen = <<~HL7.tr("\n", "\r").chop
+      MSH|^~\\&|Doctolib||Doctolib||20160720182415||SIU^S12|a40e0c06-4101-4f60-9|P|2.5.1|||||FRA|UTF-8
+      SCH||369016^DXPLANNING||||APT|||||1^MIN^15^201602250945|^CHANTELOUP^ELISE||||jdelon^DELON^Jeremie||||jdelon^DELON^Jeremie||||393923^DXPLANNING
+      PID|||DXP738874^^^DX_TEMPORY^PI~DX0738874^^^DX_TEMPORY^PI||TEST^SIMONE^^^^^D~MAIDEN NAME^SIMONE^^^^^L||19900201|F|||38 RUE GERMAIN ET ROGER LEFEVRE^^PARAY VIEILLE POSTE^^91550||C^^^simone.test@gma.com~C0655554444|C0199998888||||
+      RGS|1
+      AIS|1|A|ANGAS^CS GASTRO ANCIEN^1|201602250945|201602250945||15|MIN|||1^I^L
+      AIL|1|A|GASTRO^^^00001^^D|E
+      AIP|1|A|1196^MARTY^Olivier|M
+    HL7
+  end
+  context 'general' do
+    it do
+      msg = HL7::Message.new(@gen)
+
+      msg.enforce_encoding!
+
+      expect(msg.encoding.name).to eql(msg[:MSH.charset])
+    end
+  end
+end

--- a/spec/enforce_encoding_spec.rb
+++ b/spec/enforce_encoding_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe 'enforce encoding' do
   before :all do
-    @gen = <<~HL7.gsub("\n", "\r").chop
+    @without_multibyte = <<~HL7.gsub("\n", "\r").chop
       MSH|^~\\&|Doctolib||Doctolib||20160720182415||SIU^S12|a40e0c06-4101-4f60-9|P|2.5.1|||||FRA|UTF-8
       SCH||369016^DXPLANNING||||APT|||||1^MIN^15^201602250945|^CHANTELOUP^ELISE||||jdelon^DELON^Jeremie||||jdelon^DELON^Jeremie||||393923^DXPLANNING
       PID|||DXP738874^^^DX_TEMPORY^PI~DX0738874^^^DX_TEMPORY^PI||TEST^SIMONE^^^^^D~MAIDEN NAME^SIMONE^^^^^L||19900201|F|||38 RUE GERMAIN ET ROGER LEFEVRE^^PARAY VIEILLE POSTE^^91550||C^^^simone.test@gma.com~C0655554444|C0199998888||||
@@ -13,7 +13,7 @@ describe 'enforce encoding' do
       AIP|1|A|1196^MARTY^Olivier|M
     HL7
 
-    @bad = <<~HL7.gsub("\n", "\r").chop
+    @with_multibyte = <<~HL7.gsub("\n", "\r").chop
       MSH|^~\\&|Doctolib||Doctolib||20160720182415||SIU^S12|a40e0c06-4101-4f60-9|P|2.5.1|||||FRA|UTF-8
       SCH||369016^DXPLANNING||||APT|||||1^MIN^15^201602250945|^CHANTELOUP^ELISE||||jdelon^DELON^Joaqu\xEDn||||jdelon^DELON^Joaqu\xEDn||||393923^DXPLANNING
       PID|||DXP738874^^^DX_TEMPORY^PI~DX0738874^^^DX_TEMPORY^PI||TEST^SIMONE^^^^^D~MAIDEN NAME^SIMONE^^^^^L||19900201|F|||38 RUE GERMAIN ET ROGER LEFEVRE^^PARAY VIEILLE POSTE^^91550||C^^^simone.test@gma.com~C0655554444|C0199998888||||
@@ -25,22 +25,40 @@ describe 'enforce encoding' do
   end
 
   context 'when msh charset and text encoding agrees' do
-    it 'keeps both encoding and charset as is' do
-      msg = HL7::Message.new(@gen)
+    it 'retains encoding of message' do
+      msg = HL7::Message.new(@without_multibyte)
 
       expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset.strip)
     end
   end
 
-  context 'when msh charset and text encoding differs' do
-    it 'enforces charset on the message' do
-      msg = HL7::Message.new(@bad)
+  context 'when msh charset is UTF-8 but text has multibyte chars' do
+    it 'enforces UTF-8 on the message' do
+      msg = HL7::Message.new(@with_multibyte)
 
       expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset)
+      expect(msg.to_s).to include("Joaquín")
+      expect(msg.to_s).not_to include("Joaqu\xEDn")
     end
 
     it 'is expected to have a valid encoding' do
-      msg = HL7::Message.new(@bad)
+      msg = HL7::Message.new(@with_multibyte)
+
+      expect(msg.to_s).to be_valid_encoding
+    end
+  end
+
+  context 'when msh charset is ISO-8859-1 and text has multibyte' do
+    it 'enforces charset on the message' do
+      msg = HL7::Message.new(@with_multibyte.sub("UTF-8", "ISO-8859-1"))
+
+      expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset)
+      expect(msg.to_s).to include("Joaqu\xEDn".force_encoding("ISO-8859-1"))
+      expect(msg.to_s).not_to include("Joaquín".force_encoding("ISO-8859-1"))
+    end
+
+    it 'is expected to have a valid encoding' do
+      msg = HL7::Message.new(@with_multibyte.sub("UTF-8", "ISO-8859-1"))
 
       expect(msg.to_s).to be_valid_encoding
     end

--- a/spec/enforce_encoding_spec.rb
+++ b/spec/enforce_encoding_spec.rb
@@ -28,7 +28,9 @@ describe 'enforce encoding' do
     it 'retains encoding of message' do
       msg = HL7::Message.new(@without_multibyte)
 
-      expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset.strip)
+      msg.enforce_encoding!
+
+      expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset)
     end
   end
 
@@ -36,13 +38,17 @@ describe 'enforce encoding' do
     it 'enforces UTF-8 on the message' do
       msg = HL7::Message.new(@with_multibyte)
 
+      msg.enforce_encoding!
+
       expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset)
-      expect(msg.to_s).to include("Joaquín")
+      expect(msg.to_s).to include('Joaquín')
       expect(msg.to_s).not_to include("Joaqu\xEDn")
     end
 
     it 'is expected to have a valid encoding' do
       msg = HL7::Message.new(@with_multibyte)
+
+      msg.enforce_encoding!
 
       expect(msg.to_s).to be_valid_encoding
     end
@@ -50,15 +56,19 @@ describe 'enforce encoding' do
 
   context 'when msh charset is ISO-8859-1 and text has multibyte' do
     it 'enforces charset on the message' do
-      msg = HL7::Message.new(@with_multibyte.sub("UTF-8", "ISO-8859-1"))
+      msg = HL7::Message.new(@with_multibyte.sub('UTF-8', 'ISO-8859-1'))
+
+      msg.enforce_encoding!
 
       expect(msg.to_s.encoding.name).to eql(msg[:MSH].charset)
-      expect(msg.to_s).to include("Joaqu\xEDn".force_encoding("ISO-8859-1"))
-      expect(msg.to_s).not_to include("Joaquín".force_encoding("ISO-8859-1"))
+      expect(msg.to_s).to include("Joaqu\xEDn".force_encoding('ISO-8859-1'))
+      expect(msg.to_s).not_to include('Joaquín'.force_encoding('ISO-8859-1'))
     end
 
     it 'is expected to have a valid encoding' do
-      msg = HL7::Message.new(@with_multibyte.sub("UTF-8", "ISO-8859-1"))
+      msg = HL7::Message.new(@with_multibyte.sub('UTF-8', 'ISO-8859-1'))
+
+      msg.enforce_encoding!
 
       expect(msg.to_s).to be_valid_encoding
     end

--- a/spec/enforce_encoding_spec.rb
+++ b/spec/enforce_encoding_spec.rb
@@ -12,15 +12,7 @@ describe 'enforce encoding' do
       AIP|1|A|1196^MARTY^Olivier|M
     HL7
 
-    @with_multibyte = <<~HL7.gsub("\n", "\r").chop
-      MSH|^~\\&|Doctolib||Doctolib||20160720182415||SIU^S12|a40e0c06-4101-4f60-9|P|2.5.1|||||FRA|UTF-8
-      SCH||369016^DXPLANNING||||APT|||||1^MIN^15^201602250945|^CHANTELOUP^ELISE||||jdelon^DELON^Joaqu\xEDn||||jdelon^DELON^Joaqu\xEDn||||393923^DXPLANNING
-      PID|||DXP738874^^^DX_TEMPORY^PI~DX0738874^^^DX_TEMPORY^PI||TEST^SIMONE^^^^^D~MAIDEN NAME^SIMONE^^^^^L||19900201|F|||38 RUE GERMAIN ET ROGER LEFEVRE^^PARAY VIEILLE POSTE^^91550||C^^^simone.test@gma.com~C0655554444|C0199998888||||
-      RGS|1
-      AIS|1|A|ANGAS^CS GASTRO ANCIEN^1|201602250945|201602250945||15|MIN|||1^I^L
-      AIL|1|A|GASTRO^^^00001^^D|E
-      AIP|1|A|1196^MARTY^Olivier|M
-    HL7
+    @with_multibyte = @without_multibyte.gsub('Jeremie', "Joaqu\xEDn")
   end
 
   context 'when msh charset and text encoding agrees' do

--- a/spec/enforce_encoding_spec.rb
+++ b/spec/enforce_encoding_spec.rb
@@ -19,7 +19,7 @@ describe 'enforce encoding' do
 
       msg.enforce_encoding!
 
-      expect(msg.encoding.name).to eql(msg[:MSH.charset])
+      expect(@gen.to_s.encoding.name).to eql(msg[:MSH].charset)
     end
   end
 end

--- a/spec/enforce_encoding_spec.rb
+++ b/spec/enforce_encoding_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'spec_helper'
 
 describe 'enforce encoding' do


### PR DESCRIPTION
This PR attempts to solve two problems:

1. HL7 messages, like any string, are treated in ruby as UTF-8 even though they might contain invalid chars
2. While the MSH defines the encoding, they are sometimes not respected.

These problems are solved by:
* detecting the encoding of an hl7 message by its content before attempting to parse it
* ultimately transcoding the message in the encoding defined by the MSH header

### NOTE
This [gem](https://github.com/brianmario/charlock_holmes) does a good job of detection and transcoding and has the critical parts written in C++ (making it performant). I'd suggest we use it if there is no objection.

### Update
We already use the gem suggested (Charlock Holmes) in Doctolib